### PR TITLE
Or function helper

### DIFF
--- a/src/or.ts
+++ b/src/or.ts
@@ -1,0 +1,40 @@
+export class OrOptions {
+  public caseSensitive: boolean;
+  public strict: boolean;
+
+  constructor(caseSensitive: boolean = false, strict: boolean = true) {
+    this.caseSensitive = caseSensitive;
+    this.strict = strict;
+  }
+}
+
+export const or = (
+    comparable: string, 
+    condition1: string, 
+    condition2: string, 
+    opts: OrOptions = new OrOptions()
+  ): boolean => {
+  try {
+    const normalizedComparable = comparable.toLocaleLowerCase();
+    const normalizedCondition1 = condition1.toLocaleLowerCase();
+    const normalizedCondition2 = condition2.toLocaleLowerCase();
+  
+    if (opts.caseSensitive) {
+      if (opts.strict) {
+        return comparable === condition1 || comparable === condition2;
+      }
+  
+      return comparable == condition1 || comparable == condition2;
+    }
+  
+    if (opts.strict) {
+      return normalizedComparable === normalizedCondition1 || normalizedComparable === normalizedCondition2;
+    }
+  
+    return normalizedComparable == normalizedCondition1 || normalizedComparable == normalizedCondition2;
+  } catch (error) {
+    console.log(error);
+    // Fix this, should not return just false
+    return false;
+  }
+}

--- a/src/or.ts
+++ b/src/or.ts
@@ -9,32 +9,38 @@ export class OrOptions {
 }
 
 export const or = (
-    comparable: string, 
-    condition1: string, 
-    condition2: string, 
-    opts: OrOptions = new OrOptions()
-  ): boolean => {
+  comparable: string,
+  condition1: string,
+  condition2: string,
+  opts: OrOptions = new OrOptions()
+): boolean => {
   try {
     const normalizedComparable = comparable.toLocaleLowerCase();
     const normalizedCondition1 = condition1.toLocaleLowerCase();
     const normalizedCondition2 = condition2.toLocaleLowerCase();
-  
+
     if (opts.caseSensitive) {
       if (opts.strict) {
         return comparable === condition1 || comparable === condition2;
       }
-  
+
       return comparable == condition1 || comparable == condition2;
     }
-  
+
     if (opts.strict) {
-      return normalizedComparable === normalizedCondition1 || normalizedComparable === normalizedCondition2;
+      return (
+        normalizedComparable === normalizedCondition1 ||
+        normalizedComparable === normalizedCondition2
+      );
     }
-  
-    return normalizedComparable == normalizedCondition1 || normalizedComparable == normalizedCondition2;
+
+    return (
+      normalizedComparable == normalizedCondition1 ||
+      normalizedComparable == normalizedCondition2
+    );
   } catch (error) {
     console.log(error);
     // Fix this, should not return just false
     return false;
   }
-}
+};

--- a/test/or.test.ts
+++ b/test/or.test.ts
@@ -1,0 +1,45 @@
+import { or, OrOptions } from '../src/or';
+
+describe('Test for conditional outcomes', () => {
+  const condition1 = 'Something';
+  const condition2 = 'Something Else';
+
+  it('should resolve true for left condition', () => {
+    const comparable = 'Something';
+    const result = or(comparable, condition1, condition2);
+    expect(result).toEqual(true);
+  });
+
+  it('should resolve true for second condition', () => {
+    const comparable = 'Something Else';
+    const result = or(comparable, condition1, condition2);
+    expect(result).toEqual(true);
+  });
+
+  it('should resolve false for both conditions', () => {
+    const comparable = 'Not Something Else';
+    const result = or(comparable, condition1, condition2);
+    expect(result).toEqual(false);
+  });
+
+  it('should resolve true on case sensitivity', () => {
+    const comparable = 'Something Else';
+    const opts = new OrOptions(true);
+    const result = or(comparable, condition1, condition2, opts);
+    expect(result).toEqual(true);
+  });
+
+  it('should resolve false on case sensitivity', () => {
+    const comparable = 'Something else';
+    const opts = new OrOptions(true);
+    const result = or(comparable, condition1, condition2, opts);
+    expect(result).toEqual(false);
+  });
+
+  it('should resolve false on case sensitivity', () => {
+    const comparable = 'Something else';
+    const opts = new OrOptions(true);
+    const result = or(comparable, condition1, condition2, opts);
+    expect(result).toEqual(false);
+  });
+});


### PR DESCRIPTION
Ready for a little review, not ready to be pushed just yet. I want to add some more scenarios and test cases around them.

This function essentially handles either or conditions between two strings allowing for strict or non-strict comparison. Currently, does not support full comparison on numerals.